### PR TITLE
Clean up editor structure

### DIFF
--- a/game-editor/index.css
+++ b/game-editor/index.css
@@ -1,0 +1,23 @@
+@import '../public/css/global.css';
+
+/****************************
+        Sprite Editor
+****************************/
+.sprite-editor {
+  display: grid;
+  grid-gap: var(--macro-space-outside);
+  justify-content: center;
+  grid-template:
+    'header        header       header        ' auto
+    'drawing-tools action-tools action-tools  ' auto
+    'drawing-tools stage        color-swatches' 1fr
+    'drawing-tools frames       color-swatches' auto
+    'files         files        files         ' auto /
+    auto 1fr auto;
+  padding: var(--macro-space-inside);
+  color: #fff;
+  text-shadow: -1px -1px 0 #0003, 1px -1px 0 #0003, -1px 1px 0 #0003,
+    1px 1px 0 #0003;
+  background: var(--ui-bg);
+  user-select: none;
+}

--- a/game-editor/index.css
+++ b/game-editor/index.css
@@ -1,23 +1,2 @@
 @import '../public/css/global.css';
 
-/****************************
-        Sprite Editor
-****************************/
-.sprite-editor {
-  display: grid;
-  grid-gap: var(--macro-space-outside);
-  justify-content: center;
-  grid-template:
-    'header        header       header        ' auto
-    'drawing-tools action-tools action-tools  ' auto
-    'drawing-tools stage        color-swatches' 1fr
-    'drawing-tools frames       color-swatches' auto
-    'files         files        files         ' auto /
-    auto 1fr auto;
-  padding: var(--macro-space-inside);
-  color: #fff;
-  text-shadow: -1px -1px 0 #0003, 1px -1px 0 #0003, -1px 1px 0 #0003,
-    1px 1px 0 #0003;
-  background: var(--ui-bg);
-  user-select: none;
-}

--- a/game-editor/index.html
+++ b/game-editor/index.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Game Editor</title>
+    <link rel="stylesheet" href="index.css" />
+  </head>
+  <body>
+    <h1>Game Editor</h1>
+  </body>
+</html>

--- a/game-editor/index.js
+++ b/game-editor/index.js
@@ -4,14 +4,14 @@ const mountNode = document.createElement('div')
 mountNode.id = 'root'
 document.body.appendChild(mountNode)
 
-function levelEditor() {
+function gameEditor() {
   return html`
-    <h1>Level Editor</h1>
+    <h1>Game Editor</h1>
   `
 }
 
 export const init = () => {
-  return render(levelEditor(), mountNode)
+  return render(gameEditor(), mountNode)
 }
 
 init()

--- a/game/index.css
+++ b/game/index.css
@@ -1,4 +1,4 @@
-@import "../global.css";
+@import "../public/css/global.css";
 
 html,
 body {

--- a/game/index.html
+++ b/game/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <title>Run Unicorn Run!</title>
-    <link rel="stylesheet" href="../node_modules/normalize.css/normalize.css" />
     <link rel="stylesheet" href="index.css" />
   </head>
   <body>

--- a/index.css
+++ b/index.css
@@ -1,0 +1,6 @@
+@import '../public/css/global.css';
+
+html,
+body {
+  padding: var(--macro-space-inside);
+}

--- a/index.html
+++ b/index.html
@@ -2,18 +2,30 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Run Unicorn Run!</title>
-    <link rel="stylesheet" href="./node_modules/normalize.css/normalize.css" />
-    <link
-      rel="stylesheet"
-      href="https://use.fontawesome.com/releases/v5.12.0-1/css/all.css"
-      crossorigin="anonymous"
-    />
-    <link rel="stylesheet" href="global.css" />
+    <title>Bite Wood</title>
+    <link rel="stylesheet" href="index.css" />
   </head>
   <body>
-    <a href="/game">Game</a>
-    <a href="/sprite-editor">Sprite Editor</a>
-    <a href="/level-editor">Level Editor</a>
+    <h1>
+      Bite Wood
+    </h1>
+
+    <h2>Games</h2>
+    <ul>
+      <li><a href="/game">Game</a> <em>(Run Unicorn Run!)</em></li>
+    </ul>
+
+    <h2>Editors</h2>
+    <ul>
+      <li>
+        <a href="/game-editor">Game Editor</a>
+      </li>
+      <li>
+        <a href="/sprite-editor">Sprite Editor</a>
+      </li>
+      <li>
+        <a href="/level-editor">Level Editor</a>
+      </li>
+    </ul>
   </body>
 </html>

--- a/level-editor/index.css
+++ b/level-editor/index.css
@@ -1,0 +1,1 @@
+@import '../public/css/global.css';

--- a/level-editor/index.html
+++ b/level-editor/index.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Game Editor</title>
+    <link rel="stylesheet" href="index.css" />
+  </head>
+  <body>
+    <script src="index.js" type="module"></script>
+  </body>
+</html>

--- a/public/css/global.css
+++ b/public/css/global.css
@@ -1,3 +1,4 @@
+@import url(../../node_modules/normalize.css/normalize.css);
 @import url(/public/fonts/Pixellari/web/stylesheet.css);
 @import url(/public/css/slider.css);
 @import url(/public/css/button.css);
@@ -71,4 +72,8 @@ canvas {
 
 a {
   color: inherit;
+  text-decoration: underline;
+}
+a:hover {
+  color: var(--ui-active-color);
 }

--- a/sprite-editor/index.css
+++ b/sprite-editor/index.css
@@ -1,4 +1,4 @@
-@import '../global.css';
+@import '../public/css/global.css';
 
 /****************************
         Sprite Editor

--- a/sprite-editor/index.html
+++ b/sprite-editor/index.html
@@ -3,13 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <title>Run Unicorn Run!</title>
-    <link rel="stylesheet" href="../node_modules/normalize.css/normalize.css" />
     <link
       rel="stylesheet"
       href="https://use.fontawesome.com/releases/v5.12.0-1/css/all.css"
       crossorigin="anonymous"
     />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="index.css" />
   </head>
   <body>
     <script src="index.js" type="module"></script>


### PR DESCRIPTION
This PR just normalizes the `*-editor` directory structures and cleans up the CSS organization. I also stubbed a `game-editor` directory for the future top level editor. I tried not to touch JS as @HudsonMercer is working on TS support.

### New launch page

<img width="786" alt="image" src="https://user-images.githubusercontent.com/5067638/189576759-78715e74-8cf1-45a0-bcd0-ba478edd2531.png">

### Editor Directory Structure
```
/public
    /css
        global.css        # normalize.css and global styles

/foo-editor
    index.html            # page for the editor, imports CSS/JS
    index.css             # imports public/global.css, editor specific CSS
    index.js              # web components for the editor UI & bootstrap
```